### PR TITLE
fix integration tests for estimate fee

### DIFF
--- a/crates/pallets/starknet/src/tests/mod.rs
+++ b/crates/pallets/starknet/src/tests/mod.rs
@@ -65,7 +65,39 @@ fn get_invoke_argent_dummy() -> InvokeTransactionV1 {
         Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000019").unwrap(), /* calldata[0] */
     ];
 
-    InvokeTransactionV1 { max_fee: u64::MAX as u128, signature: vec![], nonce, sender_address, calldata, offset_version: false }
+    InvokeTransactionV1 {
+        max_fee: u64::MAX as u128,
+        signature: vec![],
+        nonce,
+        sender_address,
+        calldata,
+        offset_version: false,
+    }
+}
+
+// ref: https://github.com/argentlabs/argent-contracts-starknet/blob/develop/contracts/account/ArgentAccount.cairo
+fn get_estimate_fee_dummy() -> InvokeTransactionV1 {
+    let sender_address =
+        Felt252Wrapper::from_hex_be("0x02e63de215f650e9d7e2313c6e9ed26b4f920606fb08576b1663c21a7c4a28c5").unwrap();
+    let nonce = Felt252Wrapper::ZERO;
+    let calldata = vec![
+        Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000001").unwrap(), /* call_array_len */
+        Felt252Wrapper::from_hex_be("0x024d1e355f6b9d27a5a420c8f4b50cea9154a8e34ad30fc39d7c98d3c177d0d7").unwrap(), /* to */
+        Felt252Wrapper::from_hex_be("0x00e7def693d16806ca2a2f398d8de5951344663ba77f340ed7a958da731872fc").unwrap(), /* selector */
+        Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000000").unwrap(), /* data_offset */
+        Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000001").unwrap(), /* data_len */
+        Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000001").unwrap(), /* calldata_len */
+        Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000019").unwrap(), /* calldata[0] */
+    ];
+
+    InvokeTransactionV1 {
+        max_fee: u64::MAX as u128,
+        signature: vec![],
+        nonce,
+        sender_address,
+        calldata,
+        offset_version: true,
+    }
 }
 
 // ref: https://github.com/myBraavos/braavos-account-cairo/blob/develop/src/account/Account.cairo

--- a/crates/pallets/starknet/src/tests/mod.rs
+++ b/crates/pallets/starknet/src/tests/mod.rs
@@ -75,31 +75,6 @@ fn get_invoke_argent_dummy() -> InvokeTransactionV1 {
     }
 }
 
-// ref: https://github.com/argentlabs/argent-contracts-starknet/blob/develop/contracts/account/ArgentAccount.cairo
-fn get_estimate_fee_dummy() -> InvokeTransactionV1 {
-    let sender_address =
-        Felt252Wrapper::from_hex_be("0x02e63de215f650e9d7e2313c6e9ed26b4f920606fb08576b1663c21a7c4a28c5").unwrap();
-    let nonce = Felt252Wrapper::ZERO;
-    let calldata = vec![
-        Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000001").unwrap(), /* call_array_len */
-        Felt252Wrapper::from_hex_be("0x024d1e355f6b9d27a5a420c8f4b50cea9154a8e34ad30fc39d7c98d3c177d0d7").unwrap(), /* to */
-        Felt252Wrapper::from_hex_be("0x00e7def693d16806ca2a2f398d8de5951344663ba77f340ed7a958da731872fc").unwrap(), /* selector */
-        Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000000").unwrap(), /* data_offset */
-        Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000001").unwrap(), /* data_len */
-        Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000001").unwrap(), /* calldata_len */
-        Felt252Wrapper::from_hex_be("0x0000000000000000000000000000000000000000000000000000000000000019").unwrap(), /* calldata[0] */
-    ];
-
-    InvokeTransactionV1 {
-        max_fee: u64::MAX as u128,
-        signature: vec![],
-        nonce,
-        sender_address,
-        calldata,
-        offset_version: true,
-    }
-}
-
 // ref: https://github.com/myBraavos/braavos-account-cairo/blob/develop/src/account/Account.cairo
 fn get_invoke_braavos_dummy() -> InvokeTransactionV1 {
     let signature = vec![

--- a/crates/pallets/starknet/src/tests/query_tx.rs
+++ b/crates/pallets/starknet/src/tests/query_tx.rs
@@ -57,7 +57,7 @@ fn executable_tx_should_not_be_estimable() {
         basic_test_setup(2);
 
         let chain_id = Starknet::chain_id();
-        let mut tx = get_estimate_fee_dummy();
+        let mut tx = get_invoke_argent_dummy();
         let tx_hash = tx.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false);
         tx.signature = sign_message_hash(tx_hash);
 

--- a/crates/pallets/starknet/src/tests/query_tx.rs
+++ b/crates/pallets/starknet/src/tests/query_tx.rs
@@ -6,7 +6,7 @@ use mp_transactions::UserTransaction;
 use super::mock::default_mock::*;
 use super::mock::new_test_ext;
 use crate::tests::utils::sign_message_hash;
-use crate::tests::{get_invoke_argent_dummy, get_invoke_dummy, get_storage_read_write_dummy};
+use crate::tests::{get_estimate_fee_dummy, get_invoke_argent_dummy, get_invoke_dummy, get_storage_read_write_dummy};
 use crate::{Config, Error};
 
 #[test]
@@ -57,7 +57,7 @@ fn executable_tx_should_not_be_estimable() {
         basic_test_setup(2);
 
         let chain_id = Starknet::chain_id();
-        let mut tx = get_invoke_argent_dummy();
+        let mut tx = get_estimate_fee_dummy();
         let tx_hash = tx.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, false);
         tx.signature = sign_message_hash(tx_hash);
 
@@ -77,7 +77,7 @@ fn query_tx_should_not_be_executable() {
         basic_test_setup(2);
 
         let chain_id = Starknet::chain_id();
-        let mut tx = get_invoke_argent_dummy();
+        let mut tx = get_estimate_fee_dummy();
         let tx_hash = tx.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, true);
         tx.signature = sign_message_hash(tx_hash);
 

--- a/crates/pallets/starknet/src/tests/query_tx.rs
+++ b/crates/pallets/starknet/src/tests/query_tx.rs
@@ -6,7 +6,7 @@ use mp_transactions::UserTransaction;
 use super::mock::default_mock::*;
 use super::mock::new_test_ext;
 use crate::tests::utils::sign_message_hash;
-use crate::tests::{get_estimate_fee_dummy, get_invoke_argent_dummy, get_invoke_dummy, get_storage_read_write_dummy};
+use crate::tests::{get_invoke_argent_dummy, get_invoke_dummy, get_storage_read_write_dummy};
 use crate::{Config, Error};
 
 #[test]
@@ -63,8 +63,8 @@ fn executable_tx_should_not_be_estimable() {
 
         let tx_vec = vec![UserTransaction::Invoke(tx.clone().into())];
 
-        // it should not be valid for estimate calls
-        assert_err!(Starknet::estimate_fee(tx_vec), Error::<MockRuntime>::TransactionExecutionFailed);
+        // it should be valid for estimate calls
+        assert_ok!(Starknet::estimate_fee(tx_vec));
 
         // it should be executable
         assert_ok!(Starknet::invoke(RuntimeOrigin::none(), tx.clone().into()));
@@ -77,7 +77,8 @@ fn query_tx_should_not_be_executable() {
         basic_test_setup(2);
 
         let chain_id = Starknet::chain_id();
-        let mut tx = get_estimate_fee_dummy();
+        let mut tx = get_invoke_argent_dummy();
+        tx.offset_version = true;
         let tx_hash = tx.compute_hash::<<MockRuntime as Config>::SystemHash>(chain_id, true);
         tx.signature = sign_message_hash(tx_hash);
 


### PR DESCRIPTION
`estimate_fee` integration tests use the dummy argent invoke transaction, which breaks the tests because of the wrong `offset_version`